### PR TITLE
Set defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const startingDefaults = {
+let defaults = {
   type: 'console',
   filter: null,
   defaultTags: [],
@@ -22,23 +22,13 @@ const startingDefaults = {
     }
   }
 };
-// defaults are set globally:
-global.logr = {
-  defaults: startingDefaults
-};
 
 class Logger {
   constructor(options) {
-    // use node's 'global' namespace
-    if (options) {
-      if (options.setDefaults) {
-        global.logr.defaults = _.defaultsDeep(options, global.logr.defaults);
-      }
-      if (options.restoreDefaults) {
-        global.logr.defaults = startingDefaults;
-      }
+    if (options && options.setDefaults) {
+      defaults = _.defaultsDeep(options, defaults);
     }
-    this.config = _.defaultsDeep(options, global.logr.defaults);
+    this.config = _.defaultsDeep(options, defaults);
     this.renderers = {
       console: require('./lib/console'),
       json: require('./lib/json'),

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const defaults = {
+const startingDefaults = {
   type: 'console',
   filter: null,
   defaultTags: [],
@@ -22,11 +22,23 @@ const defaults = {
     }
   }
 };
+// defaults are set globally:
+global.logr = {
+  defaults: startingDefaults
+};
 
 class Logger {
   constructor(options) {
-    this.config = _.defaultsDeep(options, defaults);
-
+    // use node's 'global' namespace
+    if (options) {
+      if (options.setDefaults) {
+        global.logr.defaults = _.defaultsDeep(options, global.logr.defaults);
+      }
+      if (options.restoreDefaults) {
+        global.logr.defaults = startingDefaults;
+      }
+    }
+    this.config = _.defaultsDeep(options, global.logr.defaults);
     this.renderers = {
       console: require('./lib/console'),
       json: require('./lib/json'),
@@ -68,8 +80,8 @@ class Logger {
 
   log(tags, message) {
     if (arguments.length === 1) {
-        message = tags;
-        tags = [];
+      message = tags;
+      tags = [];
     }
     if (!this.config.type) {
       return;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha -u bdd test/logr.test.js"
+    "test": "mocha -u bdd test/"
   },
   "dependencies": {
     "json-stringify-safe": "^5.0.1",

--- a/test/logr.test.js
+++ b/test/logr.test.js
@@ -204,8 +204,8 @@ describe('logr', () => {
       log({ test: 123 });
       expect(lastMessage).to.equal('{"test":123}');
     });
-  });
 
+  });
 
   describe('cli', () => {
     it('should print correctly (indented, no timestamp, tags last)', () => {
@@ -252,7 +252,6 @@ describe('logr', () => {
       expect(lastMessage).to.equal('\x1b[42m  message\x1b[0m (\u001b[31mtag1\u001b[0m)');
     });
   });
-
 
   describe('json', () => {
     it('should output to json formatted', () => {

--- a/test/setDefaults.test.js
+++ b/test/setDefaults.test.js
@@ -1,0 +1,35 @@
+/* global describe, it, beforeEach */
+'use strict';
+const expect = require('chai').expect;
+const Logr = require('../');
+
+describe('logr', () => {
+  let lastMessage = null;
+
+  beforeEach((done) => {
+    const originalConsole = console.log;
+    console.log = function(msg) { //eslint-disable-line
+      lastMessage = msg;
+      originalConsole.apply(null, arguments);
+    };
+    done();
+  });
+
+  it('should let you specify a "default" config once for all instances of Logger in a project ', () => {
+    const log = new Logr({
+      setDefaults: true,
+      type: 'cli',
+      renderOptions: {
+        cli: {
+          lineColor: 'bgGreen',
+          colors: {
+            tag1: 'red'
+          }
+        }
+      }
+    });
+    const log2 = new Logr();
+    log2(['tag1'], 'message');
+    expect(lastMessage).to.equal('\x1b[42m  message\x1b[0m (\u001b[31mtag1\u001b[0m)');
+  });
+});

--- a/test/setDefaults2.test.js
+++ b/test/setDefaults2.test.js
@@ -1,0 +1,36 @@
+/* global describe, it, beforeEach */
+'use strict';
+const expect = require('chai').expect;
+const Logr = require('../');
+
+describe('logr', () => {
+  let lastMessage = null;
+
+  beforeEach((done) => {
+    const originalConsole = console.log;
+    console.log = function(msg) { //eslint-disable-line
+      lastMessage = msg;
+      originalConsole.apply(null, arguments);
+    };
+    done();
+  });
+
+  it('should preserve the defaults set in the previous test file ', () => {
+    const log2 = new Logr();
+    log2(['tag1'], 'message');
+    expect(lastMessage).to.equal('\x1b[42m  message\x1b[0m (\u001b[31mtag1\u001b[0m)');
+  });
+
+  it('should let you restore the original "defaults"  of Logger in a project ', () => {
+    const log3 = new Logr({
+      restoreDefaults: true,
+      renderOptions: {
+        console: {
+          timestamp: false
+        }
+      }
+    });
+    log3(['tag1', 'tag2'], 'message');
+    expect(lastMessage).to.equal('[tag1,tag2] message');
+  });
+});

--- a/test/setDefaults2.test.js
+++ b/test/setDefaults2.test.js
@@ -20,17 +20,4 @@ describe('logr', () => {
     log2(['tag1'], 'message');
     expect(lastMessage).to.equal('\x1b[42m  message\x1b[0m (\u001b[31mtag1\u001b[0m)');
   });
-
-  it('should let you restore the original "defaults"  of Logger in a project ', () => {
-    const log3 = new Logr({
-      restoreDefaults: true,
-      renderOptions: {
-        console: {
-          timestamp: false
-        }
-      }
-    });
-    log3(['tag1', 'tag2'], 'message');
-    expect(lastMessage).to.equal('[tag1,tag2] message');
-  });
 });


### PR DESCRIPTION
passing 'setDefaults: true' in a set of options will cause Logr to use those options as the default for all future instances of Logr in the project, regardless of what file.


this uses node's 'global' namespace, probably the most direct way to pass info between 'require' calls to the same module, let me know if this is not a suitable option.